### PR TITLE
Fix for array of interface implementations

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -173,6 +173,9 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 		k = v.Kind()
 	}
 
+	if k == reflect.Interface {
+		return Marshal(options, val)
+	}
 	if k == reflect.Struct {
 		return Marshal(options, val)
 	}

--- a/sheriff.go
+++ b/sheriff.go
@@ -173,10 +173,7 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 		k = v.Kind()
 	}
 
-	if k == reflect.Interface {
-		return Marshal(options, val)
-	}
-	if k == reflect.Struct {
+	if k == reflect.Interface || k == reflect.Struct {
 		return Marshal(options, val)
 	}
 	if k == reflect.Slice {

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -466,26 +466,36 @@ func TestMarshal_EmbeddedFieldEmpty(t *testing.T) {
 	assert.Equal(t, string(expected), string(actual))
 }
 
-type InterfacableBeta struct {
+type InterfaceableBeta struct {
 	Integer int    `json:"integer" groups:"safe"`
 	Secret  string `json:"secret"`
 }
-type InterfacableCharlie struct {
+type InterfaceableCharlie struct {
 	Integer int    `json:"integer" groups:"safe"`
 	Secret  string `json:"secret"`
 }
-type ArrayOfInterfacable []CanHazInterface
+type ArrayOfInterfaceable []CanHazInterface
 type CanHazInterface interface {
 }
 type InterfacerAlpha struct {
-	Plaintext     string              `json:"plaintext" groups:"safe"`
-	Secret        string              `json:"secret"`
-	Nested        InterfacableBeta    `json:"nested" groups:"safe"`
-	Interfaceable ArrayOfInterfacable `json:"interfacable" groups:"safe"`
+	Plaintext     string               `json:"plaintext" groups:"safe"`
+	Secret        string               `json:"secret"`
+	Nested        InterfaceableBeta    `json:"nested" groups:"safe"`
+	Interfaceable ArrayOfInterfaceable `json:"interfaceable" groups:"safe"`
 }
 
-func TestMarshal_ArrayOfInterfacable(t *testing.T) {
-	a := InterfacerAlpha{"I am plaintext", "I am a secret", InterfacableBeta{100, "Still a secret"}, ArrayOfInterfacable{InterfacableBeta{200, "Still a secret good"}, InterfacableCharlie{300, "Still a secret exellect"}}}
+func TestMarshal_ArrayOfInterfaceable(t *testing.T) {
+	a := InterfacerAlpha{
+		"I am plaintext",
+		"I am a secret",
+		InterfaceableBeta{
+			100,
+			"Still a secret",
+		},
+		ArrayOfInterfaceable{
+			InterfaceableBeta{200, "Still a secret good"},
+			InterfaceableCharlie{300, "Still a secret exellect"},
+		}}
 
 	o := &Options{
 		Groups: []string{"safe"},
@@ -496,9 +506,9 @@ func TestMarshal_ArrayOfInterfacable(t *testing.T) {
 
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
-	//{\"interfacable\":[{\"integer\":200},{\"integer\":300}],\"nested\":{\"integer\":100},\"plaintext\":\"I am plaintext\"}
+
 	expected, err := json.Marshal(map[string]interface{}{
-		"interfacable": []map[string]interface{}{
+		"interfaceable": []map[string]interface{}{
 			map[string]interface{}{"integer": 200},
 			map[string]interface{}{"integer": 300},
 		},


### PR DESCRIPTION
I ran into what I think is a bug in sheriff.  It doesn't seem to be able to handle arrays of interface implementations,  I added code and a test case which appears to confirm this.

Regards
```go
type InterfaceableBeta struct {
	Integer int    `json:"integer" groups:"safe"`
	Secret  string `json:"secret"`
}
type InterfaceableCharlie struct {
	Integer int    `json:"integer" groups:"safe"`
	Secret  string `json:"secret"`
}
type ArrayOfInterfaceable []CanHazInterface
type CanHazInterface interface {
}
type InterfacerAlpha struct {
	Plaintext     string               `json:"plaintext" groups:"safe"`
	Secret        string               `json:"secret"`
	Nested        InterfaceableBeta    `json:"nested" groups:"safe"`
	Interfaceable ArrayOfInterfaceable `json:"interfaceable" groups:"safe"`
}
	a := InterfacerAlpha{
		"I am plaintext",
		"I am a secret",
		InterfaceableBeta{
			100,
			"Still a secret",
		},
		ArrayOfInterfaceable{
			InterfaceableBeta{200, "Still a secret good"},
			InterfaceableCharlie{300, "Still a secret exellect"},
		}}
```

```
--- FAIL: TestMarshal_ArrayOfInterfaceable (0.00s)
	sheriff_test.go:459:
			Error Trace:	sheriff_test.go:459
			Error:      	Not equal:
			            	expected: "{\"interfaceable\":[{\"integer\":200},{\"integer\":300}],\"nested\":{\"integer\":100},\"plaintext\":\"I am plaintext\"}"
			            	actual  : "{\"interfaceable\":[{\"integer\":200,\"secret\":\"Still a secret good\"},{\"integer\":300,\"secret\":\"Still a secret exellect\"}],\"nested\":{\"integer\":100},\"plaintext\":\"I am plaintext\"}"

			            	Diff:
			            	--- Expected
			            	+++ Actual
			            	@@ -1 +1 @@
			            	-{"interfaceable":[{"integer":200},{"integer":300}],"nested":{"integer":100},"plaintext":"I am plaintext"}
			            	+{"interfaceable":[{"integer":200,"secret":"Still a secret good"},{"integer":300,"secret":"Still a secret exellect"}],"nested":{"integer":100},"plaintext":"I am plaintext"}
			Test:       	TestMarshal_ArrayOfInterfaceable
```
see https://github.com/liip/sheriff/commit/c0b2fa25d382957d0955073c8c7efa02ad87dfb2 for the struct that showcases the bug.
