### PR TITLE
fix: use default field name when no json tag is provided

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -74,6 +74,11 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 
 		jsonTag, jsonOpts := parseTag(field.Tag.Get("json"))
 
+		// If no json tag is provided, use the field Name
+		if jsonTag == "" {
+			jsonTag = field.Name
+		}
+
 		if jsonTag == "-" {
 			continue
 		}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -350,6 +350,36 @@ func TestMarshal_Recursive(t *testing.T) {
 	assert.Equal(t, string(expected), string(actual))
 }
 
+type TestNoJSONTagModel struct {
+	SomeData    string `groups:"test"`
+	AnotherData string `groups:"test"`
+}
+
+func TestMarshal_NoJSONTAG(t *testing.T) {
+	testModel := &TestNoJSONTagModel{
+		SomeData:    "SomeData",
+		AnotherData: "AnotherData",
+	}
+
+	o := &Options{
+		Groups: []string{"test"},
+	}
+
+	actualMap, err := Marshal(o, testModel)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"SomeData":    "SomeData",
+		"AnotherData": "AnotherData",
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}
+
 type TimeHackTest struct {
 	ATime time.Time `json:"a_time" groups:"test"`
 }


### PR DESCRIPTION
Adding default field name when no json tag is provided 
for example before : 
```
type UserInfo struct {
    ID string `"groups":"public"`
}
```
We get as an output: 
`{
  "": "A"
}
`
And now that we use default name if tag is absent we get: 
`{
  "ID": "A"
}
`
which is a similar behaviour as the go default JSON encoder  