### PR TITLE
Feat: Adding Parent group name when no groups are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,26 @@ type GroupsExample struct {
     SomethingElse string `json:"something_else" groups:"api,personal"`
 }
 ```
- 
+
+### Anonymous fields
+
+Tags added to a struct’s anonymous field propagates to the inner-fields if no other tags are specified.
+
+Example:
+
+```go
+type UserInfo struct {
+    UserPrivateInfo `groups:"private"`
+    UserPublicInfo  `groups:"public"`
+}
+type UserPrivateInfo struct {
+    Age string
+}
+type UserPublicInfo struct {
+    ID    string
+    Email string`
+}
+``` 
 ### Since
 Since specifies the version since that field is available. It's inclusive and SemVer compatible using
 [github.com/hashicorp/go-version](https://github.com/hashicorp/go-version).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ type UserPrivateInfo struct {
 }
 type UserPublicInfo struct {
     ID    string
-    Email string`
+    Email string
 }
 ``` 
 ### Since

--- a/sheriff.go
+++ b/sheriff.go
@@ -74,6 +74,11 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 
 		jsonTag, jsonOpts := parseTag(field.Tag.Get("json"))
 
+		// If no json tag is provided, use the field Name
+		if jsonTag == "" {
+			jsonTag = field.Name
+		}
+
 		if jsonTag == "-" {
 			continue
 		}

--- a/sheriff.go
+++ b/sheriff.go
@@ -109,7 +109,7 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		// we can skip the group checkif if the field is a composition field
 		isEmbeddedField := field.Anonymous && val.Kind() == reflect.Struct
 
-		if isEmbeddedField {
+		if isEmbeddedField && field.Type.Kind() == reflect.Struct {
 			tt := field.Type
 			parentGroups := strings.Split(field.Tag.Get("groups"), ",")
 			for i := 0; i < tt.NumField(); i++ {

--- a/sheriff.go
+++ b/sheriff.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 )
 
 // Options determine which struct fields are being added to the output map.
@@ -23,6 +23,9 @@ type Options struct {
 	// Specifying a since setting of "2" with the same API version specified,
 	// will not marshal the field.
 	ApiVersion *version.Version
+
+	// This is used internally so that we can propagate anonymous fields groups tag to all child field.
+	nestedGroupsMap map[string][]string
 }
 
 // MarshalInvalidTypeError is an error returned to indicate the wrong type has been
@@ -50,6 +53,12 @@ type Marshaller interface {
 func Marshal(options *Options, data interface{}) (interface{}, error) {
 	v := reflect.ValueOf(data)
 	t := v.Type()
+
+	// Initialise nestedGroupsMap,
+	// TODO: this may impact the performance, find a better place for this.
+	if options.nestedGroupsMap == nil {
+		options.nestedGroupsMap = make(map[string][]string)
+	}
 
 	checkGroups := len(options.Groups) > 0
 
@@ -99,10 +108,26 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 
 		// we can skip the group checkif if the field is a composition field
 		isEmbeddedField := field.Anonymous && val.Kind() == reflect.Struct
+
+		if isEmbeddedField {
+			tt := field.Type
+			parentGroups := strings.Split(field.Tag.Get("groups"), ",")
+			for i := 0; i < tt.NumField(); i++ {
+				nestedField := tt.Field(i)
+				options.nestedGroupsMap[nestedField.Name] = parentGroups
+			}
+		}
+
 		if !isEmbeddedField {
 			if checkGroups {
-				groups := strings.Split(field.Tag.Get("groups"), ",")
+				var groups []string
+				if field.Tag.Get("groups") != "" {
+					groups = strings.Split(field.Tag.Get("groups"), ",")
+				}
 
+				if len(groups) == 0 && options.nestedGroupsMap[field.Name] != nil {
+					groups = append(groups, options.nestedGroupsMap[field.Name]...)
+				}
 				shouldShow := listContains(groups, options.Groups)
 				if !shouldShow || len(groups) == 0 {
 					continue

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -378,6 +378,45 @@ func TestMarshal_NoJSONTAG(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
+}
+
+type UserInfo struct {
+	UserPrivateInfo `groups:"private"`
+	UserPublicInfo  `groups:"public"`
+}
+type UserPrivateInfo struct {
+	Age string
+}
+type UserPublicInfo struct {
+	ID    string
+	Email string `groups:"private"`
+}
+
+func TestMarshal_ParentInherit(t *testing.T) {
+	publicInfo := UserPublicInfo{ID: "F94", Email: "hello@hello.com"}
+	privateInfo := UserPrivateInfo{Age: "20"}
+	testModel := UserInfo{
+		UserPrivateInfo: privateInfo,
+		UserPublicInfo:  publicInfo,
+	}
+
+	o := &Options{
+		Groups: []string{"public"},
+	}
+
+	actualMap, err := Marshal(o, testModel)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"ID": "F94",
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+
 }
 
 type TimeHackTest struct {

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -350,6 +350,36 @@ func TestMarshal_Recursive(t *testing.T) {
 	assert.Equal(t, string(expected), string(actual))
 }
 
+type TestNoJSONTagModel struct {
+	SomeData    string `groups:"test"`
+	AnotherData string `groups:"test"`
+}
+
+func TestMarshal_NoJSONTAG(t *testing.T) {
+	testModel := &TestNoJSONTagModel{
+		SomeData:    "SomeData",
+		AnotherData: "AnotherData",
+	}
+
+	o := &Options{
+		Groups: []string{"test"},
+	}
+
+	actualMap, err := Marshal(o, testModel)
+	assert.NoError(t, err)
+
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(map[string]interface{}{
+		"SomeData":    "SomeData",
+		"AnotherData": "AnotherData",
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(expected), string(actual))
+}
+
 type TimeHackTest struct {
 	ATime time.Time `json:"a_time" groups:"test"`
 }


### PR DESCRIPTION
Feat: Adding Parent group name when no groups are provided

Allow fields with no groups to inherit their parent group visibility if it’s declared.
 
for example:

```
type UserInfo struct {
    UserPrivateInfo `groups:"private"`
    UserPublicInfo  `groups:"public"`
}
type UserPrivateInfo struct {
    Age string
}
type UserPublicInfo struct {
    ID    string
    Email string `groups:"private"`
}
```

Before adding this feature, if we request group tag “public” we get as an output:
`{0}`
And now that we use default parent groups we get:
`{ "ID": "A" } `

We notice also that it does only override childs with no groups.
