### PR TITLE
IncludeNoGroup

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -23,6 +23,9 @@ type Options struct {
 	// Specifying a since setting of "2" with the same API version specified,
 	// will not marshal the field.
 	ApiVersion *version.Version
+	// IncludeNoGroup determines if fields, which don't have any group tag should
+	// be included or not. Default: false
+	IncludeNoGroup bool
 }
 
 // MarshalInvalidTypeError is an error returned to indicate the wrong type has been
@@ -101,9 +104,13 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		isEmbeddedField := field.Anonymous && val.Kind() == reflect.Struct
 		if !isEmbeddedField {
 			if checkGroups {
-				groups := strings.Split(field.Tag.Get("groups"), ",")
+				_groups, ok := field.Tag.Lookup("groups")
+				groups := strings.Split(_groups, ",")
 
 				shouldShow := listContains(groups, options.Groups)
+				if (options.IncludeNoGroup == true && ok == false) {
+					shouldShow = true;
+				}
 				if !shouldShow || len(groups) == 0 {
 					continue
 				}


### PR DESCRIPTION
With this, you are able to include fields, wich don't have a `goups` Tag.
Useful if you want to include embedded Objects, from other packages.

```go
type MyModel struct {
  bongo.DocumentBase `json:",include" groups:"user,admin"`
  Username  string   `json:"username" groups:"user,admin"`
  Password  string   `json:"-"`
}
```

IncludeNoGroup: `true`:

```json
{
  "_id": "XYZ",
  "_created": "2018-02-28 11:59:57",
  "_modified": "2018-02-28 12:00:00",
  "username": "test"
}
```

IncludeNoGroup: false:

```json
{
  "username": "test"
}
```

You think that would be useful? I can submit tests also. 