### PR TITLE
fix map key string conversation panic by string alia type

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -232,7 +232,7 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			dest[key.Interface().(string)] = d
+			dest[key.String()] = d
 		}
 		return dest, nil
 	}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -649,3 +649,17 @@ func TestMarshal_Inet(t *testing.T) {
 
 	assert.Equal(t, string(expected), string(actual))
 }
+
+func TestMarshal_AliaString(t *testing.T) {
+	type ResourceName string
+	type ResourceList map[ResourceName]string
+	v := struct {
+		Resources ResourceList
+	}{
+		Resources: map[ResourceName]string{
+			"cpu": "100",
+		},
+	}
+	_, err := Marshal(&Options{}, &v)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Say we have:

```go
type ResourceName string
ResourceList map[ResourceName]Resource
```

to marshal `ResourceList` map leads to a panic by  `key.Interface().(string)` .