### PR TITLE
fix: Marshal empty interface

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -52,6 +52,9 @@ type Marshaller interface {
 // In all other cases we can't derive the type in a meaningful way and is therefore an `interface{}`.
 func Marshal(options *Options, data interface{}) (interface{}, error) {
 	v := reflect.ValueOf(data)
+	if !v.IsValid() {
+		return data, nil
+	}
 	t := v.Type()
 
 	// Initialise nestedGroupsMap,

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -663,3 +663,15 @@ func TestMarshal_AliaString(t *testing.T) {
 	_, err := Marshal(&Options{}, &v)
 	assert.NoError(t, err)
 }
+
+type EmptyInterfaceStruct struct {
+	Data interface{} `json:"data"`
+}
+
+func TestMarshal_EmptyInterface(t *testing.T) {
+	v := EmptyInterfaceStruct{}
+	o := &Options{}
+
+	_, err := Marshal(o, v)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Related issue: https://github.com/liip/sheriff/issues/19

Fix the panic "reflect: call of reflect.Value.IsNil on struct Value" when marshalling an empty interface.