### PR TITLE
Fix slice regression caused by #32

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -218,7 +218,7 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 	k := v.Kind()
 
 	switch k {
-	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Interface, reflect.Map, reflect.Ptr:
 		if v.IsNil() {
 			return val, nil
 		}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -630,8 +630,8 @@ func TestMarshal_ArrayOfInterfaceable(t *testing.T) {
 type TestInlineStruct struct {
 	// explicitly testing unexported fields
 	// golangci-lint complains about it and that's ok to ignore.
-	tableName        struct{ Test string } `json:"-"`  //nolint
-	tableNameWithTag struct{ Test string } `json:"foo"`  //nolint
+	tableName        struct{ Test string } `json:"-"`   //nolint
+	tableNameWithTag struct{ Test string } `json:"foo"` //nolint
 
 	Field  string  `json:"field"`
 	Field2 *string `json:"field2"`
@@ -732,4 +732,18 @@ func TestMarshal_BooleanPtrMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(marshal), string(expect))
+}
+
+func TestMarshal_NilSlice(t *testing.T) {
+	var stringSlice []string // nil slice
+
+	marshalSlice, err := Marshal(&Options{}, stringSlice)
+	assert.NoError(t, err)
+
+	jsonResult, err := json.Marshal(marshalSlice)
+	assert.NoError(t, err)
+
+	expect := "[]"
+
+	assert.Equal(t, expect, string(jsonResult))
 }


### PR DESCRIPTION
Slices that are nil are empty and valid.
The change introduced by #32 which fixes #31 has changed how
nil slices are marshaled (`null` instead of `[]`).

Fix this regression by removing slices from the check.