### PR TITLE
marshals nil slices/arrays like expected and equivalent to json.marshal

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -218,7 +218,7 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 	k := v.Kind()
 
 	switch k {
-	case reflect.Interface, reflect.Map, reflect.Ptr:
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 		if v.IsNil() {
 			return val, nil
 		}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -743,6 +743,20 @@ func TestMarshal_NilSlice(t *testing.T) {
 	jsonResult, err := json.Marshal(marshalSlice)
 	assert.NoError(t, err)
 
+	expect := "null"
+
+	assert.Equal(t, expect, string(jsonResult))
+}
+
+func TestMarshal_EmptySlice(t *testing.T) {
+	var stringSlice = []string{} // empty slice
+
+	marshalSlice, err := Marshal(&Options{}, stringSlice)
+	assert.NoError(t, err)
+
+	jsonResult, err := json.Marshal(marshalSlice)
+	assert.NoError(t, err)
+
 	expect := "[]"
 
 	assert.Equal(t, expect, string(jsonResult))


### PR DESCRIPTION
In comparison to json.Marshal sheriff converts nil arrays to empty arrays.

This Pull Request fixes the difference between json.Marshal and sheriff.Marshal