### PR TITLE
fix: Marshal panics on nil pointer

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -56,7 +56,7 @@ type Marshaller interface {
 // In all other cases we can't derive the type in a meaningful way and is therefore an `interface{}`.
 func Marshal(options *Options, data interface{}) (interface{}, error) {
 	v := reflect.ValueOf(data)
-	if !v.IsValid() {
+	if !v.IsValid() || v.Kind() == reflect.Ptr && v.IsNil() {
 		return data, nil
 	}
 	t := v.Type()

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -747,3 +747,10 @@ func TestMarshal_NilSlice(t *testing.T) {
 
 	assert.Equal(t, expect, string(jsonResult))
 }
+
+func TestMarshal_NilPointer(t *testing.T) {
+	var a *AModel
+	v, err := Marshal(&Options{}, a)
+	assert.Nil(t, v)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes panic when `sheriff.Marshal` called with a nil pointer.