### PR TITLE
Use ordered map to guarantee consistency of JSON ordering

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -82,52 +82,52 @@ func Example() {
 	// Version 1 output:
 	// [
 	//   {
-	//     "name": "Alice",
-	//     "username": "alice"
+	//     "username": "alice",
+	//     "name": "Alice"
 	//   },
 	//   {
-	//     "name": "Bob",
-	//     "username": "bob"
+	//     "username": "bob",
+	//     "name": "Bob"
 	//   }
 	// ]
 	//
 	// Version 2 output:
 	// [
 	//   {
+	//     "username": "alice",
 	//     "name": "Alice",
 	//     "roles": [
 	//       "user",
 	//       "admin"
-	//     ],
-	//     "username": "alice"
+	//     ]
 	//   },
 	//   {
+	//     "username": "bob",
 	//     "name": "Bob",
 	//     "roles": [
 	//       "user"
-	//     ],
-	//     "username": "bob"
+	//     ]
 	//   }
 	// ]
 	//
 	// Version 2 output with personal group too:
 	// [
 	//   {
+	//     "username": "alice",
 	//     "email": "alice@example.org",
 	//     "name": "Alice",
 	//     "roles": [
 	//       "user",
 	//       "admin"
-	//     ],
-	//     "username": "alice"
+	//     ]
 	//   },
 	//   {
+	//     "username": "bob",
 	//     "email": "bob@example.org",
 	//     "name": "Bob",
 	//     "roles": [
 	//       "user"
-	//     ],
-	//     "username": "bob"
+	//     ]
 	//   }
 	// ]
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/stretchr/testify v1.9.0
+	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a h1:DxppxFKRqJ8WD6oJ3+ZXKDY0iMONQDl5UTg2aTyHh8k=
+gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -852,7 +852,7 @@ func TestMarshal_BooleanPtrMap(t *testing.T) {
 	expect, err := json.Marshal(toMarshal)
 	assert.NoError(t, err)
 
-	assert.Equal(t, string(marshal), string(expect))
+	assert.JSONEq(t, string(marshal), string(expect))
 }
 
 func TestMarshal_NilSlice(t *testing.T) {

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -2,6 +2,7 @@ package sheriff
 
 import (
 	"encoding/json"
+	"gitlab.com/c0b/go-ordered-json"
 	"net"
 	"testing"
 	"time"
@@ -52,17 +53,21 @@ func TestMarshal_GroupsValidGroup(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"only_group_test":       "OnlyGroupTest",
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"only_group_test": "OnlyGroupTest",
+		"group_test_and_other": "GroupTestAndOther",
 		"omit_empty_group_test": "OmitEmptyGroupTest",
-		"group_test_and_other":  "GroupTestAndOther",
-		"map_string_struct": map[string]map[string]bool{
+		"slice_string": ["test", "bla"],
+		"map_string_struct": {
 			"firstModel": {
-				"something": true,
-			},
-		},
-		"slice_string": []string{"test", "bla"},
-	})
+				"something": true
+			}
+		}
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -90,16 +95,20 @@ func TestMarshal_GroupsValidGroupOmitEmpty(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"only_group_test":      "OnlyGroupTest",
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"only_group_test": "OnlyGroupTest",
 		"group_test_and_other": "GroupTestAndOther",
-		"map_string_struct": map[string]map[string]bool{
+		"slice_string": ["test", "bla"],
+		"map_string_struct": {
 			"firstModel": {
-				"something": true,
-			},
-		},
-		"slice_string": []string{"test", "bla"},
-	})
+				"something": true
+			}
+		}
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -154,21 +163,25 @@ func TestMarshal_GroupsNoGroups(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"default_marshal":       "DefaultMarshal",
-		"only_group_test":       "OnlyGroupTest",
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"default_marshal": "DefaultMarshal",
+		"only_group_test": "OnlyGroupTest",
 		"only_group_test_other": "OnlyGroupTestOther",
-		"group_test_and_other":  "GroupTestAndOther",
-		"map_string_struct": map[string]map[string]bool{
-			"firstModel": {
-				"something":      true,
-				"something_else": true,
-			},
-		},
-		"omit_empty":            "OmitEmpty",
+		"group_test_and_other": "GroupTestAndOther",
+		"omit_empty": "OmitEmpty",
 		"omit_empty_group_test": "OmitEmptyGroupTest",
-		"include_empty_tag":     "IncludeEmptyTag",
-	})
+		"map_string_struct": {
+			"firstModel": {
+				"something": true,
+				"something_else": true
+			}
+		},
+		"include_empty_tag": "IncludeEmptyTag"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -196,14 +209,21 @@ func TestMarshal_GroupsValidGroupIncludeEmptyTag(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"default_marshal":      "DefaultMarshal",
-		"only_group_test":      "OnlyGroupTest",
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"default_marshal": "DefaultMarshal",
+		"only_group_test": "OnlyGroupTest",
 		"group_test_and_other": "GroupTestAndOther",
-		"omit_empty":           "OmitEmpty",
-		"slice_string":         []string{"test", "bla"},
-		"include_empty_tag":    "IncludeEmptyTag",
-	})
+		"omit_empty": "OmitEmpty",
+		"slice_string": [
+			"test",
+			"bla"
+		],
+		"include_empty_tag": "IncludeEmptyTag"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -241,11 +261,15 @@ func TestMarshal_Versions(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]string{
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"default_marshal": "DefaultMarshal",
 		"until_20":        "Until20",
-		"until_21":        "Until21",
-	})
+		"until_21":        "Until21"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -264,12 +288,16 @@ func TestMarshal_Versions(t *testing.T) {
 	actual, err = json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err = json.Marshal(map[string]string{
+	m = ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"default_marshal": "DefaultMarshal",
-		"until_20":        "Until20",
-		"until_21":        "Until21",
-		"since_20":        "Since20",
-	})
+		"until_20": "Until20",
+		"until_21": "Until21",
+		"since_20": "Since20"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err = json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -288,12 +316,16 @@ func TestMarshal_Versions(t *testing.T) {
 	actual, err = json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err = json.Marshal(map[string]string{
+	m = ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"default_marshal": "DefaultMarshal",
-		"until_21":        "Until21",
-		"since_20":        "Since20",
-		"since_21":        "Since21",
-	})
+		"until_21": "Until21",
+		"since_20": "Since20",
+		"since_21": "Since21"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err = json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -312,11 +344,15 @@ func TestMarshal_Versions(t *testing.T) {
 	actual, err = json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err = json.Marshal(map[string]string{
+	m = ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"default_marshal": "DefaultMarshal",
-		"since_20":        "Since20",
-		"since_21":        "Since21",
-	})
+		"since_20": "Since20",
+		"since_21": "Since21"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err = json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -364,25 +400,32 @@ func TestMarshal_Recursive(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"some_data": "SomeData",
-		"groups_data": []map[string]interface{}{
+		"groups_data": [
 			{
-				"only_group_test":       "OnlyGroupTest",
+				"only_group_test": "OnlyGroupTest",
+				"group_test_and_other": "GroupTestAndOther",
 				"omit_empty_group_test": "OmitEmptyGroupTest",
-				"group_test_and_other":  "GroupTestAndOther",
-				"map_string_struct": map[string]map[string]bool{
+				"slice_string": [
+					"test",
+					"bla"
+				],
+				"map_string_struct": {
 					"firstModel": {
-						"something": true,
-					},
-				},
-				"slice_string": []string{"test", "bla"},
-			},
-		},
-		"is_marshaller": map[string]interface{}{
-			"should_marshal": "test",
-		},
-	})
+						"something": true
+					}
+				}
+			}
+		],
+		"is_marshaller": {
+			"should_marshal": "test"
+		}
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -409,10 +452,14 @@ func TestMarshal_NoJSONTAG(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"SomeData":    "SomeData",
-		"AnotherData": "AnotherData",
-	})
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"SomeData": "SomeData",
+		"AnotherData": "AnotherData"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -448,9 +495,13 @@ func TestMarshal_ParentInherit(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"ID": "F94",
-	})
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
+		"ID": "F94"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -596,10 +647,14 @@ func TestMarshal_EmbeddedField(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"bar": "World",
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"foo": "Hello",
-	})
+		"bar": "World"
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -676,14 +731,18 @@ func TestMarshal_ArrayOfInterfaceable(t *testing.T) {
 	actual, err := json.Marshal(actualMap)
 	assert.NoError(t, err)
 
-	expected, err := json.Marshal(map[string]interface{}{
-		"interfaceable": []map[string]interface{}{
-			map[string]interface{}{"integer": 200},
-			map[string]interface{}{"integer": 300},
-		},
-		"nested":    map[string]interface{}{"integer": 100},
+	m := ordered.NewOrderedMap()
+	err = m.UnmarshalJSON([]byte(`{
 		"plaintext": "I am plaintext",
-	})
+		"nested": { "integer": 100 },
+		"interfaceable": [
+			{ "integer": 200 },
+			{ "integer": 300 }
+		]
+	}`))
+	assert.NoError(t, err)
+
+	expected, err := json.Marshal(m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(expected), string(actual))
@@ -847,9 +906,8 @@ func TestMarshal_User(t *testing.T) {
 
 	v, err := Marshal(&Options{}, j)
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{"test": "12", "testb": "true", "testf": "12", "tests": "test"}, v)
 
-	d, err := json.Marshal(j)
+	d, err := json.Marshal(v)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"test":"12","testb":"true","testf":"12","tests":"\"test\""}`, string(d))
+	assert.Equal(t, `{"test":"12","testb":"true","testf":"12","tests":"test"}`, string(d))
 }


### PR DESCRIPTION
Uses [orderedmap](gitlab.com/c0b/go-ordered-json) instead of `map[string]interface{}` to maintain ordering of entries in the marshalled JSON.

I appreciate there are some disadvantages to this.
1. It adds an additional dependency. 
2. It will add a little overhead - although I believe this will be very minimal based on the operations in `orderedmap`

As you note then JSON is not designed to be ordered and as such this is maybe a little redundant.
I've opened this as we are looking to use this library to replace the default json.Marshall across a large code base, and refactoring some tests due to the ordering change would be prohibitively difficult!

fixes #49
