### PR TITLE
Add custom decider

### DIFF
--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -855,7 +855,7 @@ func TestMarshal_User(t *testing.T) {
 	assert.Equal(t, `{"test":"12","testb":"true","testf":"12","tests":"\"test\""}`, string(d))
 }
 
-func TestMarshal_CustomDecider(t *testing.T) {
+func TestMarshal_CustomFieldFilter(t *testing.T) {
 	type testStruct struct {
 		TestValue   string `json:"test"`
 		SecretValue string `json:"secret" hidden:"true"`
@@ -866,7 +866,7 @@ func TestMarshal_CustomDecider(t *testing.T) {
 	}
 
 	o := &Options{
-		Decider: func(field reflect.StructField) (bool, error) {
+		FieldFilter: func(field reflect.StructField) (bool, error) {
 			return field.Tag.Get("hidden") == "", nil
 		},
 	}


### PR DESCRIPTION
An idea! Easier to demonstrate via a PR!

We use date based versioning instead of semantic versioning in our application. As such the default `since`/`until` don't work for us.

This PR adds the ability to overwrite the "decider" with a custom one. This allows any custom logic to be written to decide which fields should be included/excluded.

If a "decider" option is not provided then the existing logic will be used - as such this is a non-breaking change.