### PR TITLE
Allow using a custom KV store to keep consistent JSON ordering

### DIFF
--- a/kvstore.go
+++ b/kvstore.go
@@ -1,0 +1,17 @@
+package sheriff
+
+// kvStore is the default implementation of the KVStore interface that sheriff converts a struct into.
+// It is the fastest option, but does result in a re-ordering of the final JSON properties.
+type kvStore map[string]interface{}
+
+// Set inserts the value into the map at the given key.
+func (m kvStore) Set(k string, v interface{}) {
+	m[k] = v
+}
+
+// Each applies the callback function to each element in the map.
+func (m kvStore) Each(f func(k string, v interface{})) {
+	for k, v := range m {
+		f(k, v)
+	}
+}

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -846,13 +846,12 @@ func TestMarshal_User(t *testing.T) {
 		TestS: "test",
 	}
 
-	v, err := Marshal(&Options{}, j)
+	m, err := Marshal(&Options{}, j)
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{"test": "12", "testb": "true", "testf": "12", "tests": "test"}, v)
 
-	d, err := json.Marshal(j)
+	d, err := json.Marshal(m)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"test":"12","testb":"true","testf":"12","tests":"\"test\""}`, string(d))
+	assert.Equal(t, `{"test":"12","testb":"true","testf":"12","tests":"test"}`, string(d))
 }
 
 func TestMarshal_CustomFieldFilter(t *testing.T) {
@@ -873,6 +872,7 @@ func TestMarshal_CustomFieldFilter(t *testing.T) {
 	m, err := Marshal(o, v)
 	assert.NoError(t, err)
 
-	// ensure the "secret" value is not present in the marshalled map
-	assert.Equal(t, map[string]interface{}{"test": "teststring"}, m)
+	d, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"test":"teststring"}`, string(d))
 }


### PR DESCRIPTION
See https://github.com/liip/sheriff/pull/50 for full discussion

Fixes: #49 

Allows for overwriting the default `map[string]interface{}` to allow for consistent ordering in the generated JSON.