### PR TITLE
Non optional nil fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/ezoic/sheriff
+
+go 1.16
+
+require (
+	github.com/hashicorp/go-version v1.3.0
+	github.com/liip/sheriff v0.11.1
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-version v0.0.0-20161031182605-e96d38404026/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/liip/sheriff v0.11.1 h1:52YGzskXFPSEnwfEtXnbPiMKKXJGm5IP45s8Ogw0Wyk=
+github.com/liip/sheriff v0.11.1/go.mod h1:nVTQYHxfdIfOHnk5FREt4j6cnaSlJPUfXFVORfgGmTo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sheriff.go
+++ b/sheriff.go
@@ -84,6 +84,12 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		// we want the childs exposed at the toplevel to be
 		// consistent with the embedded json marshaller
 		if val.Kind() == reflect.Ptr {
+			if val.IsNil() { // For pointer fields with nil value, and omitempty not set, we set to nil (null) in JSON
+				if !jsonOpts.Contains("omitempty") {
+					dest[jsonTag] = nil
+				}
+				continue
+			}
 			val = val.Elem()
 		}
 

--- a/sheriff.go
+++ b/sheriff.go
@@ -88,7 +88,7 @@ func Marshal(options *Options, data interface{}) (interface{}, error) {
 		}
 
 		// we can skip the group checkif if the field is a composition field
-		isEmbeddedField := field.Anonymous && val.Kind() == reflect.Struct
+		isEmbeddedField := field.Anonymous && jsonTag == "" && val.Kind() == reflect.Struct
 		if !isEmbeddedField {
 			if checkGroups {
 				groups := strings.Split(field.Tag.Get("groups"), ",")

--- a/sheriff_test.go
+++ b/sheriff_test.go
@@ -464,3 +464,42 @@ func TestMarshal_EmbeddedFieldEmpty(t *testing.T) {
 
 	assert.Equal(t, string(expected), string(actual))
 }
+
+type PointerFieldModel struct {
+	OptionalField *string `json:"optional_field,omitempty"`
+	RequiredField *string `json:"required_field"`
+	OtherField    *string `json:"other_field"`
+}
+
+func TestMarshal_PointerFields(t *testing.T) {
+	// Create a test model instance with nil pointer fields
+	otherFieldValue := "SomeValue"
+	testModel := &PointerFieldModel{
+		OptionalField: nil,
+		RequiredField: nil,
+		OtherField:    &otherFieldValue,
+	}
+
+	o := &Options{
+		Groups:     []string{},
+		ApiVersion: nil,
+	}
+
+	// Marshal the test model
+	actualMap, err := Marshal(o, testModel)
+	assert.NoError(t, err)
+
+	// Convert the result to JSON
+	actual, err := json.Marshal(actualMap)
+	assert.NoError(t, err)
+
+	// Define the expected JSON result
+	expected, err := json.Marshal(map[string]interface{}{
+		"required_field": nil,
+		"other_field":    "SomeValue",
+	})
+	assert.NoError(t, err)
+
+	// Compare the actual and expected JSON results
+	assert.Equal(t, string(expected), string(actual))
+}


### PR DESCRIPTION
Adding support for pointer fields with nil value and "omitempty=false"

This fixes a panic for pointer fields defined _without_ "omitempty" whose value
is set to nil. They are now properly marshalled as "null" in the resulting JSON.

Use case:
- An ID field or other value that needs to be represented as "unset", and it's important for the returned JSON data to convey the unset, or "null"/"undefined" value explicitly. Plus, it's a valid combination that was throwing panics.

Although including "omitempty" will prevent the panic, there are valid cases where the API intentionally wants to send back a `null` value.