### PR TITLE
Fix pointer marshal

### DIFF
--- a/sheriff.go
+++ b/sheriff.go
@@ -282,10 +282,21 @@ func marshalValue(options *Options, v reflect.Value) (interface{}, error) {
 	// types which are e.g. structs, slices or maps and implement one of the following interfaces should not be
 	// marshalled by sheriff because they'll be correctly marshalled by json.Marshal instead.
 	// Otherwise (e.g. net.IP) a byte slice may be output as a list of uints instead of as an IP string.
+	// This needs to be checked for both value and pointer types.
 	switch val.(type) {
 	case json.Marshaler, encoding.TextMarshaler, fmt.Stringer:
 		return val, nil
 	}
+
+	if v.CanAddr() {
+		addrVal := v.Addr().Interface()
+
+		switch addrVal.(type) {
+		case json.Marshaler, encoding.TextMarshaler, fmt.Stringer:
+			return addrVal, nil
+		}
+	}
+
 	k := v.Kind()
 
 	switch k {


### PR DESCRIPTION
There is current support for structs that have a json marshaller in the form or
```
func (c Custom) MarshalJSON() ([]byte, error) {
```

However this does not work with the following case where `MarshalJSON` has a pointer reciever.
```
func (c *Custom) MarshalJSON() ([]byte, error) {
```

This PR fixes this case, and adds test for both the existing functionality and the new form.